### PR TITLE
refactor

### DIFF
--- a/src/maps-api.ts
+++ b/src/maps-api.ts
@@ -1,20 +1,8 @@
 import axios from 'axios';
 import { AutoCompleteAddressResponse, CountryCode, TomTomAddressResult } from './types';
 
-// https://developer.tomtom.com/search-api/documentation/search-service/fuzzy-search
-export async function getPlaceAutocomplete(key: string, address: string): Promise<AutoCompleteAddressResponse[]> {
-    if (!address) {
-        return Promise.reject(new Error('Address is required'));
-    }
-    const tomtomSearchApiEndpoint = `https://api.tomtom.com/search/2/search/${address}.json`;
-    const autocomplete = await axios.get(tomtomSearchApiEndpoint, {
-        params: {
-            key,
-            countrySet: CountryCode.AUS,
-            limit: 100,
-        },
-    });
-    return autocomplete.data.results.map((result: TomTomAddressResult): AutoCompleteAddressResponse => {
+export const mapTomTomResults = async (results: TomTomAddressResult[]): Promise<AutoCompleteAddressResponse[]> => {
+    return results.map((result: TomTomAddressResult): AutoCompleteAddressResponse => {
         const {
             id,
             address: { streetNumber, countryCode, country, freeformAddress, municipality },
@@ -28,4 +16,28 @@ export async function getPlaceAutocomplete(key: string, address: string): Promis
             municipality,
         };
     });
-}
+};
+
+// https://developer.tomtom.com/search-api/documentation/search-service/fuzzy-search
+export const getPlaceAutocomplete = async (key: string, address: string): Promise<AutoCompleteAddressResponse[]> => {
+    if (!key) {
+        throw new Error('API key is required');
+    }
+    if (!address) {
+        throw new Error('Address is required');
+    }
+    const tomtomSearchApiEndpoint = `https://api.tomtom.com/search/2/search/${address}.json`;
+    try {
+        const autocomplete = await axios.get(tomtomSearchApiEndpoint, {
+            params: {
+                key,
+                countrySet: CountryCode.AUS,
+                limit: 100,
+            },
+        });
+
+        return mapTomTomResults(autocomplete.data.results);
+    } catch (error) {
+        throw new Error('failed to retrieve data');
+    }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 export interface TomTomAddressResult {
     type: string;
     id: string;
+    score: number,
     address: TomTomAddress;
 }
 

--- a/test/maps-search.test.ts
+++ b/test/maps-search.test.ts
@@ -1,9 +1,9 @@
 import { config } from 'dotenv';
 import { describe } from '@jest/globals';
-import { getPlaceAutocomplete } from '../src/maps-api';
+import { getPlaceAutocomplete, mapTomTomResults } from '../src/maps-api';
 import { getAutoCompleteDetails } from '../src';
 import { AppConfig } from '../src/types';
-import { addressResults } from './test-data';
+import { addressResults, tomtomAddressResult } from './test-data';
 
 config();
 
@@ -72,12 +72,26 @@ describe('Tomtom Places E2E Tests', () => {
             expect(res[0].country).toStrictEqual('Australia');
         });
 
-        it('handles error', async () => {
+        it('handles not a real address', async () => {
+            const fakeAddress = '!!%*^&%#$(&^';
+            expect(getPlaceAutocomplete(config.apiKey, fakeAddress)).rejects.toThrow('failed to retrieve data');
+        });
+
+        it('handles error when no address is passed', async () => {
             expect(getPlaceAutocomplete(config.apiKey, '')).rejects.toThrow('Address is required');
+        });
+
+        it('handles error when no api key is passed', async () => {
+            const localAddress = '1 Nicholson Street Melbourne';
+            expect(getPlaceAutocomplete('', localAddress)).rejects.toThrow('API key is required');
         });
 
         it('handles incorrect api key', async () => {
             expect(getPlaceAutocomplete('123', 'Charlotte Street')).rejects.toThrow();
+        });
+        it('should map results to AutoCompleteAddressResponse', async () => {
+            const results = await mapTomTomResults(tomtomAddressResult);
+            expect(results).toEqual([addressResults]);
         });
     });
 });

--- a/test/test-data.ts
+++ b/test/test-data.ts
@@ -1,4 +1,4 @@
-import { AutoCompleteAddressResponse } from '../src/types';
+import { AutoCompleteAddressResponse, TomTomAddressResult } from '../src/types';
 
 export const addressResults: AutoCompleteAddressResponse = {
     country: 'Australia',
@@ -8,3 +8,25 @@ export const addressResults: AutoCompleteAddressResponse = {
     placeId: 'rCNDG-nd6wVVI-BBUfid4g',
     streetNumber: '1',
 };
+
+export const tomtomAddressResult: TomTomAddressResult[] = [
+    {
+        type: 'Point Address',
+        id: 'rCNDG-nd6wVVI-BBUfid4g',
+        score: 11.954627037,
+        address: {
+            streetNumber: '1',
+            streetName: 'Nicholson Street',
+            municipalitySubdivision: 'East Melbourne',
+            municipality: 'Melbourne',
+            countrySecondarySubdivision: 'Melbourne',
+            countrySubdivision: 'Victoria',
+            postalCode: '3002',
+            countryCode: 'AU',
+            country: 'Australia',
+            countryCodeISO3: 'AUS',
+            freeformAddress: '1 Nicholson Street, East Melbourne, Victoria, 3002',
+            localName: 'East Melbourne',
+        },
+    },
+];


### PR DESCRIPTION
The purpose of this PR is to highlight some possible improvements to my initial implementation of the be-maps-search code challenge.

They are:
* Refactor `getPlaceAutocomplete` to separate the call to tomtom and the business logic
* Add an additional check to the `getPlaceAutocomplete` function to check if an API key is being passing the the request
* Added some additional testing to cover more use cases then my original pass on the challenge